### PR TITLE
Set `undefines` _after_ parsing `cmakelists`

### DIFF
--- a/cmake_configure_file.py
+++ b/cmake_configure_file.py
@@ -156,9 +156,6 @@ def _setup_definitions(args):
         else:
             result[item] = '1'
 
-    for item in args.undefines:
-        result[item] = None
-
     cmakelist_keys = set()
     for filename in args.cmakelists:
         with open(filename, 'r') as cmakelist:
@@ -166,6 +163,9 @@ def _setup_definitions(args):
                 definition = _extract_definition(line, result)
                 result.update(definition)
                 cmakelist_keys.update(definition.keys())
+
+    for item in args.undefines:
+        result[item] = None
 
     return result, cmakelist_keys
 


### PR DESCRIPTION
Set `undefines` _after_ parsing `cmakelists`.

This is needed to `/* #undef HAVE_CJSON */` in https://github.com/PointCloudLibrary/pcl/blob/pcl-1.15.0/pcl_config.h.in#L60 which is otherwise overwritten by https://github.com/PointCloudLibrary/pcl/blob/pcl-1.15.0/CMakeLists.txt#L443