### PR TITLE
Support tabs and/or spaces between '#' and 'cmakedefine'

### DIFF
--- a/cmake_configure_file.py
+++ b/cmake_configure_file.py
@@ -15,7 +15,7 @@ import sys
 from collections import OrderedDict
 
 # Looks like "#cmakedefine VAR ..." or "#cmakedefine01 VAR".
-_cmakedefine = re.compile(r'^(\s*)#cmakedefine(01)? ([^ \r\n]+)(.*?)([\r\n]+)')
+_cmakedefine = re.compile(r'^(\s*)#([ \t]*)cmakedefine(01)? ([^ \r\n]+)(.*?)([\r\n]+)')
 
 # Looks like "@VAR@" or "${VAR}".
 _varsubst = re.compile(r'^(.*?)(@[^ ]+?@|\$\{[^ ]+?\})(.*)([\r\n]*)')
@@ -49,7 +49,7 @@ def _transform_cmake(*, line, definitions, strict):
     # Replace define statements.
     match = _cmakedefine.match(line)
     if match:
-        blank, maybe01, var, rest, newline = match.groups()
+        blank, blank_hash, maybe01, var, rest, newline = match.groups()
         if var not in definitions:
             defined = False
             if strict:
@@ -58,10 +58,10 @@ def _transform_cmake(*, line, definitions, strict):
             defined = definitions[var] is not None
             used_vars.add(var)
         if maybe01:
-            line = blank + '#define ' + var + [' 0', ' 1'][defined] + newline
+            line = blank + '#' + blank_hash + 'define ' + var + [' 0', ' 1'][defined] + newline
             return line, used_vars
         elif defined:
-            line = blank + '#define ' + var + rest + newline
+            line = blank + '#' + blank_hash + 'define ' + var + rest + newline
         else:
             line = blank + '/* #undef ' + var + ' */' + newline
             return line, used_vars


### PR DESCRIPTION
Since CMake 3.10 the result lines (with the exception of the #undef comments) can be indented using spaces and/or tabs between _#_  and _cmakedefine_ or _cmakedefine01_. This whitespace indentation should be preserved in the output lines:

```c
#  cmakedefine VAR
#  cmakedefine01 VAR
```
should be replaced, if `VAR` is defined, with
```c
#  define VAR
#  define VAR 1
```

_cmake_configure_file_ must be able to handle this type of whitespace indentation. Currently, it does not recognize it and therefore does not replace it during code generation.

Reference: https://cmake.org/cmake/help/latest/command/configure_file.html#transformations
