### PR TITLE
Replace deprecated usage of rules_python

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@python_versions//3.12:defs.bzl", "py_binary")
+load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_license//rules:license.bzl", "license")
 
 exports_files([


### PR DESCRIPTION
Per https://github.com/bazel-contrib/rules_python/blob/main/docs/toolchains.md#other-toolchain-details, `load("@python_versions//3.12:defs.bzl", "py_binary")` is deprecated and produces warnings. Replace it with new usage.